### PR TITLE
Layer arrays in instance scope

### DIFF
--- a/src/Leaflet.LayerGroup.Collision.js
+++ b/src/Leaflet.LayerGroup.Collision.js
@@ -6,11 +6,11 @@ function extensions(parentClass) { return {
 
 	initialize: function (options) {
 		parentClass.prototype.initialize.call(this, options);
-        this._originalLayers = [];
-        this._visibleLayers = [];
-        this._staticLayers = [];
-        this._rbush = [];
-        this._cachedRelativeBoxes = [];		
+		this._originalLayers = [];
+		this._visibleLayers = [];
+		this._staticLayers = [];
+		this._rbush = [];
+		this._cachedRelativeBoxes = [];		
 		this._margin = options.margin || 0;
 		this._rbush = null;
 	},

--- a/src/Leaflet.LayerGroup.Collision.js
+++ b/src/Leaflet.LayerGroup.Collision.js
@@ -4,15 +4,13 @@ var isMSIE8 = !('getComputedStyle' in window && typeof window.getComputedStyle =
 
 function extensions(parentClass) { return {
 
-	_originalLayers: [],
-	_visibleLayers: [],
-	_staticLayers: [],
-	_rbush: [],
-	_cachedRelativeBoxes: [],
-	_margin: 0,
-
 	initialize: function (options) {
 		parentClass.prototype.initialize.call(this, options);
+        this._originalLayers = [];
+        this._visibleLayers = [];
+        this._staticLayers = [];
+        this._rbush = [];
+        this._cachedRelativeBoxes = [];		
 		this._margin = options.margin || 0;
 		this._rbush = null;
 	},


### PR DESCRIPTION
The layer arrays is currently set on the prototype object, which means that they're shared among different instances. This don't allow us to use the plugin for more than one layer on a map. 

This pull request defines the arrays in the initialize method, which fixes the issue. 